### PR TITLE
Split service names for ros versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,10 @@ foreach(ros1_message_package ${ros1_message_packages})
   # TODO(karsten1987): This is currently a workaround to work with ROS 2 classloader
   # rather than ROS 1 classloader.
   if(NOT "${ros1_message_package}" STREQUAL "nodelet")
-    find_ros1_package(${ros1_message_package} REQUIRED)
-    list(APPEND prefixed_ros1_message_packages "ros1_${ros1_message_package}")
+    find_ros1_package(${ros1_message_package})
+    if(ros1_${ros1_message_package}_FOUND)
+      list(APPEND prefixed_ros1_message_packages "ros1_${ros1_message_package}")
+    endif()
   endif()
 endforeach()
 

--- a/include/ros1_bridge/factory.hpp
+++ b/include/ros1_bridge/factory.hpp
@@ -292,23 +292,23 @@ public:
   }
 
   ServiceBridge1to2 service_bridge_1_to_2(
-    ros::NodeHandle & ros1_node, rclcpp::Node::SharedPtr ros2_node, const std::string & name)
+    ros::NodeHandle & ros1_node, rclcpp::Node::SharedPtr ros2_node, const std::string & ros1_name, const std::string & ros2_name)
   {
     ServiceBridge1to2 bridge;
-    bridge.client = ros2_node->create_client<ROS2_T>(name);
+    bridge.client = ros2_node->create_client<ROS2_T>(ros2_name);
     auto m = &ServiceFactory<ROS1_T, ROS2_T>::forward_1_to_2;
     auto f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
       std::placeholders::_2);
-    bridge.server = ros1_node.advertiseService<ROS1Request, ROS1Response>(name, f);
+    bridge.server = ros1_node.advertiseService<ROS1Request, ROS1Response>(ros1_name, f);
     return bridge;
   }
 
   ServiceBridge2to1 service_bridge_2_to_1(
-    ros::NodeHandle & ros1_node, rclcpp::Node::SharedPtr ros2_node, const std::string & name)
+    ros::NodeHandle & ros1_node, rclcpp::Node::SharedPtr ros2_node, const std::string & ros1_name, const std::string & ros2_name)
   {
     ServiceBridge2to1 bridge;
-    bridge.client = ros1_node.serviceClient<ROS1_T>(name);
+    bridge.client = ros1_node.serviceClient<ROS1_T>(ros1_name);
     auto m = &ServiceFactory<ROS1_T, ROS2_T>::forward_2_to_1;
     std::function<
       void(
@@ -318,7 +318,7 @@ public:
     f = std::bind(
       m, this, bridge.client, ros2_node->get_logger(), std::placeholders::_1,
       std::placeholders::_2, std::placeholders::_3);
-    bridge.server = ros2_node->create_service<ROS2_T>(name, f);
+    bridge.server = ros2_node->create_service<ROS2_T>(ros2_name, f);
     return bridge;
   }
 

--- a/include/ros1_bridge/factory_interface.hpp
+++ b/include/ros1_bridge/factory_interface.hpp
@@ -107,10 +107,10 @@ class ServiceFactoryInterface
 {
 public:
   virtual ServiceBridge1to2 service_bridge_1_to_2(
-    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &) = 0;
+    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &, const std::string &) = 0;
 
   virtual ServiceBridge2to1 service_bridge_2_to_1(
-    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &) = 0;
+    ros::NodeHandle &, rclcpp::Node::SharedPtr, const std::string &, const std::string &) = 0;
 };
 
 }  // namespace ros1_bridge

--- a/src/dynamic_bridge.cpp
+++ b/src/dynamic_bridge.cpp
@@ -314,7 +314,7 @@ void update_bridge(
         "ros1", details.at("package"), details.at("name"));
       if (factory) {
         try {
-          service_bridges_2_to_1[name] = factory->service_bridge_2_to_1(ros1_node, ros2_node, name);
+          service_bridges_2_to_1[name] = factory->service_bridge_2_to_1(ros1_node, ros2_node, name, name);
           printf("Created 2 to 1 bridge for service %s\n", name.data());
         } catch (std::runtime_error & e) {
           fprintf(stderr, "Failed to created a bridge: %s\n", e.what());
@@ -335,7 +335,7 @@ void update_bridge(
         "ros2", details.at("package"), details.at("name"));
       if (factory) {
         try {
-          service_bridges_1_to_2[name] = factory->service_bridge_1_to_2(ros1_node, ros2_node, name);
+          service_bridges_1_to_2[name] = factory->service_bridge_1_to_2(ros1_node, ros2_node, name, name);
           printf("Created 1 to 2 bridge for service %s\n", name.data());
         } catch (std::runtime_error & e) {
           fprintf(stderr, "Failed to created a bridge: %s\n", e.what());


### PR DESCRIPTION
Splits the names for the ROS services so that different names in ROS1 & ROS2 can be used.

Furthermore, includes a small change in the `CMakeLists.txt`, so that it compiles with the full workspace of `im-vps`.