### PR TITLE
Use solely found ros1 message packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,10 @@ foreach(ros1_message_package ${ros1_message_packages})
   # TODO(karsten1987): This is currently a workaround to work with ROS 2 classloader
   # rather than ROS 1 classloader.
   if(NOT "${ros1_message_package}" STREQUAL "nodelet")
-    find_ros1_package(${ros1_message_package} REQUIRED)
-    list(APPEND prefixed_ros1_message_packages "ros1_${ros1_message_package}")
+    find_ros1_package(${ros1_message_package})
+    if(ros1_${ros1_message_package}_FOUND)
+      list(APPEND prefixed_ros1_message_packages "ros1_${ros1_message_package}")
+    endif()
   endif()
 endforeach()
 

--- a/ros1_bridge/__init__.py
+++ b/ros1_bridge/__init__.py
@@ -472,17 +472,20 @@ class ServiceMappingRule(MappingRule):
 def determine_package_pairs(ros1_msgs, ros2_msgs, mapping_rules):
     pairs = []
     # determine package names considered equal between ROS 1 and ROS 2
-    ros1_suffix = '_msgs'
-    ros2_suffixes = ['_msgs', '_interfaces']
+    ros_suffixes = ['_msgs', '_interfaces']
     ros1_package_names = {m.package_name for m in ros1_msgs}
     ros2_package_names = {m.package_name for m in ros2_msgs}
     for ros1_package_name in ros1_package_names:
-        if not ros1_package_name.endswith(ros1_suffix):
+        for ros1_suffix in ros_suffixes:
+            if ros1_package_name.endswith(ros1_suffix):
+                break
+        else:
             continue
+        
         ros1_package_basename = ros1_package_name[:-len(ros1_suffix)]
 
         for ros2_package_name in ros2_package_names:
-            for ros2_suffix in ros2_suffixes:
+            for ros2_suffix in ros_suffixes:
                 if ros2_package_name.endswith(ros2_suffix):
                     break
             else:


### PR DESCRIPTION
Only the pkg that are found are used to generate mappings in the ros1-bridge. With this PR the ros1-bridge should compile with the fully compiled im-vps workspace instead of only the msg-pkg. It should fix [this](https://github.com/Intermodalics/im-vps/pull/720#pullrequestreview-439143333).